### PR TITLE
- Ui Bottom Menu layout tweaks

### DIFF
--- a/240psuite/PCE/240pSuite.c
+++ b/240psuite/PCE/240pSuite.c
@@ -253,7 +253,7 @@ void RefreshMain()
 	drawmenutext(2, "Audio tests");
 	drawmenutext(3, "Hardware tools");
 	
-	row = 19;
+	row = 22;
 	DrawMenuBottom(4, 1);
 }
 
@@ -281,7 +281,7 @@ void RefreshVideoTests()
 	drawmenutext(7, "Horizontal Stripes");
 	drawmenutext(8, "Checkerboard");
 	drawmenutext(9, "Backlit Zone Test");
-	row++;
+	row = 22;
 	DrawMenuBottom(10, 0);
 }
 
@@ -466,7 +466,7 @@ void RefreshAudioTests()
 	drawmenutext(2, "MDFourier");
 	drawmenutext(3, "Audio Clipping");
 	
-	row++;
+	row = 22;
 	DrawMenuBottom(4, 0);
 }
 

--- a/240psuite/PCE/tests_sound.c
+++ b/240psuite/PCE/tests_sound.c
@@ -847,7 +847,7 @@ void RefreshHardwareTests()
 	drawmenutext(0, "Controller Test");
 	drawmenutext(1, "Memory Viewer");
 	
-	row++;
+	row = 22;
 	DrawMenuBottom(2, 0);
 }
 


### PR DESCRIPTION
These 2 quick patches help lock down the absolute onscreen location for the various bottom menu items to row 22 across all menus for a more uniform layout and consistent Ui experience.