### PR TITLE
PCE - Update HuC URL's to new pce-devel repo

### DIFF
--- a/240psuite/PCE/240pSuite.c
+++ b/240psuite/PCE/240pSuite.c
@@ -20,7 +20,7 @@
  *
  *
  *  This version of the suite is compiled with HuC from:
- *    https://github.com/jbrandwood/huc
+ *    https://github.com/pce-devel/huc
  *
  */
 
@@ -757,7 +757,7 @@ void RefreshCredits()
 	set_font_pal(15);
 	put_string("SDK:", HPOS+2, row++);
 	set_font_pal(14);
-	put_string("HuC https://github.com/jbrandwood/huc", HPOS+2, row++);
+	put_string("HuC https://github.com/pce-devel/huc", HPOS+2, row++);
 	row++;
 	
 	set_font_pal(15);

--- a/240psuite/PCE/pceas_patch/proc.c
+++ b/240psuite/PCE/pceas_patch/proc.c
@@ -1,5 +1,5 @@
 /* This patch is just documented for historic purposes
- * it is already included in https://github.com/jbrandwood/huc
+ * it is already included in https://github.com/pce-devel/huc
  */
 
 #include <stdio.h>


### PR DESCRIPTION
Updates the last few mentions of the old repo location for HuC to point to the new repo