### PR TITLE
Updated DC build to use latest KOS version.

### DIFF
--- a/240psuite/Dreamcast/PVR/Makefile
+++ b/240psuite/Dreamcast/PVR/Makefile
@@ -1,5 +1,6 @@
 TARGET = main
 OPT = -O3 -Wfatal-errors -Wall -Wextra
+KOS_ROMDISK_DIR = romdisk
 
 #Full release compile
 all: CFLAGS = $(OPT) -fomit-frame-pointer -DDREAMCAST
@@ -70,12 +71,6 @@ kmg:
 	gzip romdisk/*.kmg
 	gzip romdisk/480/*.kmg
 	rm -f romdisk.o romdisk.img
-
-romdisk.img:
-	$(KOS_GENROMFS) -f romdisk.img -d romdisk -v
-
-romdisk.o: romdisk.img
-	$(KOS_BASE)/utils/bin2o/bin2o romdisk.img romdisk romdisk.o
 
 ip:
 	makeip -l ../IP/logo.png ../IP/ip.txt ../IP/IP.BIN -f

--- a/240psuite/Dreamcast/PVR/hardware.c
+++ b/240psuite/Dreamcast/PVR/hardware.c
@@ -1181,8 +1181,9 @@ void buffer_printf(char *fmt, ... )
 /* Local copy of the returned buffer for maple stuff */
 unsigned char 	recv_buff[1024 + 32];
 
-static void vbl_allinfo_callback(maple_frame_t * frm) {
+static void vbl_allinfo_callback(maple_state_t *st, maple_frame_t *frm) {
 	maple_response_t	*resp;
+	(void)st;
 
 	/* So.. did we get a response? */
 	resp = (maple_response_t *)frm->recv_buf;
@@ -2992,7 +2993,7 @@ void MicrophoneTest()
 	Function int 1: 0xfe000000  Function int 2: 0x00000000
 	Region:         0x01        Connection:     0x01
 	Product Name & License: Dreamcast Gun
-	  Produced By or Under License FroÅ SEGA ENTERPRISES,LTD.
+	  Produced By or Under License Froï¿½ SEGA ENTERPRISES,LTD.
 	Standby power: 0x00dc (220mW) Max: 0x012c (300mW)
 
 	========================================================================

--- a/240psuite/Dreamcast/PVR/main.c
+++ b/240psuite/Dreamcast/PVR/main.c
@@ -44,10 +44,7 @@
 #define TEST_VIDEO
 #endif
 
-/* romdisk */
-extern uint8 romdisk[];
-KOS_INIT_ROMDISK(romdisk);
-KOS_INIT_FLAGS(INIT_DEFAULT);
+KOS_INIT_FLAGS(INIT_DEFAULT | INIT_FS_ROMDISK);
 
 void TestPatternsMenu(ImagePtr title, ImagePtr sd);
 void TestPatternsColorMenu(ImagePtr title, ImagePtr sd);
@@ -69,8 +66,7 @@ int main(void)
 	controller	*st = NULL;
 	char		error[256];
 
-	if(cdrom_init() != 0)
-		dbglog(DBG_ERROR, "Could not initialize GD-ROM\n");
+	cdrom_init();
 	if(cdrom_spin_down() != ERR_OK)
 		dbglog(DBG_ERROR,"Could not stop GD-ROM from spinning\n");
 


### PR DESCRIPTION
BACKGROUND:
- KOS is prepping to release KOSv2.1.0. This is an update to the tip of master just before release to do bug and performance checks.
- Everything built and ran great. I did not see any regressions at all; however, I was building with "make nofftserial," as I didn't have the FFTW library set up.
- I was testing with the latest dc-tool/dc-load-ip and the BBA.
- I was not positive whether timing on things like the audio lag test were still perfect or not, on account of using a crappy HDMI USB capture card for capturing video from the DC.

CHANGES:
1) Including a romdisk is now simplified in KOS. You simply set the
   KOS_ROMDISK_DIR variable within your Makefile to point to the romdisk
directory and then include KOS's Make rules, and it will be automatically generated and linked to the binary, provided you also have INIT_FS_ROMDISK in your KOS_INIT_FLAGS().
2) Fixed a build issue when building without FFTW: sip_copy() was still
   called but was never defined, causing a linker issue.
    - Moved the function and #ifndef NO_FFTW around to enable it even without NO_FFTW.