### PR TITLE
N64 ROM devcontainer

### DIFF
--- a/.devcontainer/N64/Dockerfile
+++ b/.devcontainer/N64/Dockerfile
@@ -1,15 +1,11 @@
 FROM debian:bookworm-slim
 
-ARG SC64_DEPLOYER_VERSION=v2.18.1
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install build-essential doxygen git python3 wget -y && \
     wget https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-x86_64.deb && \
     dpkg -i gcc-toolchain-mips64-x86_64.deb && \
     rm gcc-toolchain-mips64-x86_64.deb && \
-    wget https://github.com/Polprzewodnikowy/SummerCart64/releases/download/$SC64_DEPLOYER_VERSION/sc64-deployer-linux-$SC64_DEPLOYER_VERSION.tar.gz && \
-    tar -xf sc64-deployer-linux-$SC64_DEPLOYER_VERSION.tar.gz -C /usr/local/bin && \
-    rm sc64-deployer-linux-$SC64_DEPLOYER_VERSION.tar.gz && \
     git config --global --add safe.directory "*" && \
     SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" && \
     echo "$SNIPPET" >> "/root/.bashrc"

--- a/.devcontainer/N64/Dockerfile
+++ b/.devcontainer/N64/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:bookworm-slim
+
+ARG SC64_DEPLOYER_VERSION=v2.18.1
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install build-essential doxygen git python3 wget -y && \
+    wget https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-x86_64.deb && \
+    dpkg -i gcc-toolchain-mips64-x86_64.deb && \
+    rm gcc-toolchain-mips64-x86_64.deb && \
+    wget https://github.com/Polprzewodnikowy/SummerCart64/releases/download/$SC64_DEPLOYER_VERSION/sc64-deployer-linux-$SC64_DEPLOYER_VERSION.tar.gz && \
+    tar -xf sc64-deployer-linux-$SC64_DEPLOYER_VERSION.tar.gz -C /usr/local/bin && \
+    rm sc64-deployer-linux-$SC64_DEPLOYER_VERSION.tar.gz && \
+    git config --global --add safe.directory "*" && \
+    SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" && \
+    echo "$SNIPPET" >> "/root/.bashrc"

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "N64FlashcartMenu",
+    "name": "240pTestSuite-N64",
     "build": {
         "dockerfile": "Dockerfile"
     },

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -8,7 +8,7 @@
     ],
     "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
-    "postCreateCommand": "rm -f ./tiny3d && git clone https://github.com/ArtemioUrbina/tiny3d --depth 1 && cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && cd ../tiny3d && make -j4 && make -C tools/gltf_importer -j4",
+    "postCreateCommand": "rm -rf ./tiny3d && git clone https://github.com/ArtemioUrbina/tiny3d --depth 1 && cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && cd ../tiny3d && make -j4 && make -C tools/gltf_importer -j4",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -8,7 +8,7 @@
     ],
     "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
-    "postCreateCommand": "cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j",
+    "postCreateCommand": "cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && mkdir ./libs/tiny3d && cd ./libs/tiny3d && git checkout -f https://github.com/ArtemioUrbina/tiny3d",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -6,7 +6,7 @@
     "mounts": [
         "source=n64-240psuite-bashhistory,target=/commandhistory,type=volume"
     ],
-    "postCreateCommand": "git submodule update --init && cd ${localWorkspaceFolder}/240psuite/N64/libdragon/ && make clobber -j && make libdragon tools -j && make install tools-install -j",
+    "postCreateCommand": "git submodule update --init && cd ./240psuite/N64/libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j",
     "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
     "customizations": {

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -4,7 +4,7 @@
         "dockerfile": "Dockerfile"
     },
     "mounts": [
-        "source=n64-240psuite-bashhistory,target=/commandhistory,type=volume"
+        "source=240psuite-n64-bashhistory,target=/commandhistory,type=volume"
     ],
     "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
     "workspaceFolder": "/workspace",

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "N64FlashcartMenu",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "mounts": [
+        "source=n64-240psuite-bashhistory,target=/commandhistory,type=volume"
+    ],
+    "postCreateCommand": "git submodule update --init && cd ${localWorkspaceFolder}/240psuite/N64/libdragon/ && make clobber -j && make libdragon tools -j && make install tools-install -j",
+    "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
+    "workspaceFolder": "/workspace",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.makefile-tools"
+            ],
+            "settings": {
+                "git.ignoredRepositories": [
+                    "libdragon"
+                ]
+            }
+        }
+    }
+}

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -8,7 +8,7 @@
     ],
     "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
-    "postCreateCommand": "cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && mkdir ./libs/tiny3d && cd ./libs/tiny3d && git checkout -f https://github.com/ArtemioUrbina/tiny3d",
+    "postCreateCommand": "rm -f ./tiny3d && git clone https://github.com/ArtemioUrbina/tiny3d --depth 1 && cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && cd ../tiny3d && make -j4 && make -C tools/gltf_importer -j4",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -6,9 +6,9 @@
     "mounts": [
         "source=n64-240psuite-bashhistory,target=/commandhistory,type=volume"
     ],
-    "postCreateCommand": "git submodule update --init && cd ./240psuite/N64/libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j",
     "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
+    "postCreateCommand": "cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=crlf
+# These are all bash scripts and should use lf
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.vscode
 
 # Ignore N64 build files
+!*/N64/filesystem/help/*.txt
 */N64/filesystem/*
 */N64/build/*
 */N64/*.z64

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /.vscode
 
 # Ignore N64 build files
-*/N64/tiny3d/*
+*/N64/tiny3d*
 !*/N64/filesystem/help/*.txt
 */N64/filesystem/*
 */N64/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /.vscode
 
 # Ignore N64 build files
-*/N64/libs/*
+*/N64/tiny3d/*
 !*/N64/filesystem/help/*.txt
 */N64/filesystem/*
 */N64/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # Ignore editor specific config folders/files
 /.vscode
+
+# Ignore N64 build files
+*/N64/filesystem/*
+*/N64/build/*
+*/N64/*.z64

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore editor specific config folders/files
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.vscode
 
 # Ignore N64 build files
+*/N64/libs/*
 !*/N64/filesystem/help/*.txt
 */N64/filesystem/*
 */N64/build/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "240psuite/N64/libdragon"]
+	path = 240psuite/N64/libdragon
+	url = https://github.com/DragonMinded/libdragon
+	branch = preview
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 	ignore = dirty
 [submodule "240psuite/N64/libs/tiny3d"]
 	path = 240psuite/N64/libs/tiny3d
-	url = https://github.com/HailToDodongo/tiny3d
+	url = https://github.com/ArtemioUrbina/tiny3d
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,7 @@
 	url = https://github.com/DragonMinded/libdragon
 	branch = preview
 	ignore = dirty
+[submodule "240psuite/N64/libs/tiny3d"]
+	path = 240psuite/N64/libs/tiny3d
+	url = https://github.com/HailToDodongo/tiny3d
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,3 @@
 	url = https://github.com/DragonMinded/libdragon
 	branch = preview
 	ignore = dirty
-[submodule "240psuite/N64/libs/tiny3d"]
-	path = 240psuite/N64/libs/tiny3d
-	url = https://github.com/ArtemioUrbina/tiny3d
-	branch = main

--- a/240psuite/N64/Makefile
+++ b/240psuite/N64/Makefile
@@ -15,7 +15,6 @@ src = $(wildcard *.c)
 ASSETS_PNG = $(wildcard assets/*.png)
 ASSETS_PNG_CONV = $(addprefix filesystem/,$(notdir $(ASSETS_PNG:%.png=%.sprite)))
 
-#commented to iterate on builds and testing via USB upload
 ASSETS_WAV = $(wildcard assets/*.wav)
 ASSETS_WAV_CONV = $(addprefix filesystem/,$(notdir $(ASSETS_WAV:%.wav=%.wav64)))
 
@@ -28,11 +27,11 @@ AUDIOCONV_FLAGS ?= --wav-compress 0
 #MKSPRITE_EXTRA_FLAGS ?=--verbose
 MKSPRITE_EXTRA_FLAGS ?=
 
-#We need this for the older flash cart we use
-N64_CHKSUM = $(N64_BINDIR)/chksum64
+# We may need this for the older flash cart we use
+# N64_CHKSUM = $(N64_BINDIR)/chksum64
 
 all: 240pSuite.z64
-#	@$(N64_CHKSUM) 240pSuite.z64 >/dev/null
+#	 @$(N64_CHKSUM) 240pSuite.z64 >/dev/null
 
 filesystem/%.sprite: assets/%.png
 	@mkdir -p $(dir $@)

--- a/240psuite/N64/Makefile
+++ b/240psuite/N64/Makefile
@@ -1,10 +1,14 @@
+PROJECT_NAME = 240pSuite
+
+.DEFAULT_GOAL := all
+
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
 # Remove the -fdiagnostics-color=always flag
 N64_C_AND_CXX_FLAGS := $(filter-out -fdiagnostics-color=always, $(N64_C_AND_CXX_FLAGS))
 
-T3D_INST=$(N64_INST)/tiny3d
+T3D_INST=./libs/tiny3d
 include $(T3D_INST)/t3d.mk
 
 src = $(wildcard *.c)
@@ -28,7 +32,7 @@ MKSPRITE_EXTRA_FLAGS ?=
 N64_CHKSUM = $(N64_BINDIR)/chksum64
 
 all: 240pSuite.z64
-	@$(N64_CHKSUM) 240pSuite.z64 >/dev/null
+#	@$(N64_CHKSUM) 240pSuite.z64 >/dev/null
 
 filesystem/%.sprite: assets/%.png
 	@mkdir -p $(dir $@)

--- a/240psuite/N64/Makefile
+++ b/240psuite/N64/Makefile
@@ -8,7 +8,7 @@ include $(N64_INST)/include/n64.mk
 # Remove the -fdiagnostics-color=always flag
 N64_C_AND_CXX_FLAGS := $(filter-out -fdiagnostics-color=always, $(N64_C_AND_CXX_FLAGS))
 
-T3D_INST=./libs/tiny3d
+T3D_INST?= tiny3d
 include $(T3D_INST)/t3d.mk
 
 src = $(wildcard *.c)

--- a/240psuite/N64/README.md
+++ b/240psuite/N64/README.md
@@ -1,0 +1,21 @@
+## Developer Documentation
+
+You can use a devcontainer in VSCode to ease development.
+
+### A quickstart video tutorial on how to set up your environment 
+[![Devcontainer quickstart guide](http://img.youtube.com/vi/h05ufOsRgZU/0.jpg)](http://www.youtube.com/watch?v=h05ufOsRgZU "Devcontainer quickstart guide").
+
+## Building
+Use `make clean && make all` within the terminal window.
+
+
+## Submodules
+To update all submodules to the latest versions, use `git submodule update --remote` from a terminal window when in the root directory.
+
+### Libdragon
+This is the underlying SDK used for N64 builds.
+This repo currently uses the `preview` branch as a submodule at a specific commit.
+
+### Tiny3D
+This is a library used, located in the `libs` directory.
+This repo currently uses the `main` branch as a submodule at a specific commit.

--- a/240psuite/N64/README.md
+++ b/240psuite/N64/README.md
@@ -18,4 +18,5 @@ This repo currently uses the `preview` branch as a submodule at a specific commi
 
 ### Tiny3D
 This is a library used, located in the `libs` directory.
+***Note*** this currently uses a fork until https://github.com/HailToDodongo/tiny3d/pull/11 is available.
 This repo currently uses the `main` branch as a submodule at a specific commit.

--- a/240psuite/N64/README.md
+++ b/240psuite/N64/README.md
@@ -1,13 +1,19 @@
 ## Developer Documentation
 
-You can use a devcontainer in VSCode to ease development.
+You can use a devcontainer in supported IDE's (such as VSCode) or the commandline to ease development.
 
-### A quickstart video tutorial on how to set up your environment 
+### A quickstart video tutorial on how you could set up your environment 
 [![Devcontainer quickstart guide](http://img.youtube.com/vi/h05ufOsRgZU/0.jpg)](http://www.youtube.com/watch?v=h05ufOsRgZU "Devcontainer quickstart guide").
 
 ## Building
 Use `make clean && make all` within the terminal window.
 
+## Libraries
+
+### Tiny3D
+This is a library used for 3d models, (located in the root workspace directory, when using a devcontainer).
+***Note*** this currently uses a fork until https://github.com/HailToDodongo/tiny3d/pull/11 is available.
+This repo currently uses the `main` branch and uses the latest commit.
 
 ## Submodules
 To update all submodules to the latest versions, use `git submodule update --remote` from a terminal window when in the root directory.
@@ -15,8 +21,3 @@ To update all submodules to the latest versions, use `git submodule update --rem
 ### Libdragon
 This is the underlying SDK used for N64 builds.
 This repo currently uses the `preview` branch as a submodule at a specific commit.
-
-### Tiny3D
-This is a library used, located in the `libs` directory.
-***Note*** this currently uses a fork until https://github.com/HailToDodongo/tiny3d/pull/11 is available.
-This repo currently uses the `main` branch as a submodule at a specific commit.


### PR DESCRIPTION
Adds ability to build the N64 ROM using a devcontainer.

libdragon has been added as a submodule to pin it to a specific version.
Tiny3d is installed automatically through the devcontainer.

It also adds `.gitignore` to exclude build file, and `.gitarrtibutes` to keep line endings and end of files in check when using different OSes.

I have also added a `README.md` to help.

It currently comments out the `N64_CHKSUM` as this complicates builds, and should be fixed by Krikzz or libdragon, taking account that it is due to the CRC check of the ED64 OS.