### PR TITLE
N64 Fix devcontainer

### DIFF
--- a/.devcontainer/N64/devcontainer.json
+++ b/.devcontainer/N64/devcontainer.json
@@ -8,7 +8,7 @@
     ],
     "workspaceMount": "source=${localWorkspaceFolder}/240psuite/N64/,target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
-    "postCreateCommand": "rm -rf ./tiny3d && git clone https://github.com/ArtemioUrbina/tiny3d --depth 1 && cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && cd ../tiny3d && make -j4 && make -C tools/gltf_importer -j4",
+    "postCreateCommand": "rm -rf ./libdragon && git clone https://github.com/dragonminded/libdragon -b preview --depth 1 && rm -rf ./tiny3d && git clone https://github.com/HailToDodongo/tiny3d --depth 1 && cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && cd ../tiny3d && make -j4 && make -C tools/gltf_importer -j4",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Ignore N64 build files
 */N64/tiny3d*
+*/N64/libdragon*
 !*/N64/filesystem/help/*.txt
 */N64/filesystem/*
 */N64/build/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "240psuite/N64/libdragon"]
-	path = 240psuite/N64/libdragon
-	url = https://github.com/DragonMinded/libdragon
-	branch = preview
-	ignore = dirty

--- a/240psuite/N64/README.md
+++ b/240psuite/N64/README.md
@@ -12,12 +12,8 @@ Use `make clean && make all` within the terminal window.
 
 ### Tiny3D
 This is a library used for 3d models, (located in the root workspace directory, when using a devcontainer).
-***Note*** this currently uses a fork until https://github.com/HailToDodongo/tiny3d/pull/11 is available.
 This repo currently uses the `main` branch and uses the latest commit.
 
-## Submodules
-To update all submodules to the latest versions, use `git submodule update --remote` from a terminal window when in the root directory.
-
 ### Libdragon
-This is the underlying SDK used for N64 builds.
-This repo currently uses the `preview` branch as a submodule at a specific commit.
+This is the underlying SDK used for N64 builds, (located in the root workspace directory, when using a devcontainer).
+This repo currently uses the `preview` branch and uses the latest commit.


### PR DESCRIPTION
Given the changes in master to remove the submodule for libdragon (I guess you are not a fan of them).

* Download libdragon as part of the devcontainer post create commands.
* Update .gitignore to exclude the libdragon dir.
* Use official tiny3d repo (now the required change has been merged).
* Remove submodule properly.
* Update readme.