### PR TITLE
Migrate GameCube/Wii versions to libogc2

### DIFF
--- a/240psuite/Wii/240pSuite/Makefile
+++ b/240psuite/Wii/240pSuite/Makefile
@@ -12,12 +12,12 @@ PLATFORM ?= wii
 TARGET		:=	$(notdir $(CURDIR))
 
 ifeq ($(PLATFORM),wii)
-include $(DEVKITPPC)/wii_rules
+include $(DEVKITPRO)/libogc2/wii_rules
 TARGET:="$(TARGET)_wii"
 EXTRA_LIBS=-lwiiuse -lbte
 EXTRA_FLAGS=-DWII_VERSION
 else
-include $(DEVKITPPC)/gamecube_rules
+include $(DEVKITPRO)/libogc2/gamecube_rules
 TARGET:="$(TARGET)_cube"
 EXTRA_FLAGS=-DGC_VERSION
 endif

--- a/240psuite/Wii/240pSuite/source/240psuite.c
+++ b/240psuite/Wii/240pSuite/source/240psuite.c
@@ -50,11 +50,13 @@ void ColorPatternsMenu(ImagePtr title, ImagePtr sd);
 void GeometryPatternsMenu(ImagePtr title, ImagePtr sd);
 void DrawMenuFooter(u8 r, u8 g, u8 b);
 
+s8 HWButton = -1;
 #ifdef WII_VERSION
-s8 HWButton = -1; 
 void WiiResetPressed();
 void WiiPowerPressed();
 void WiimotePowerPressed(s32 chan);
+#else
+void GCResetPressed();
 #endif
 
 int main(int argc, char **argv) 
@@ -67,6 +69,8 @@ int main(int argc, char **argv)
 	SYS_SetResetCallback(WiiResetPressed);
 	SYS_SetPowerCallback(WiiPowerPressed);
 	WPAD_SetPowerButtonCallback(WiimotePowerPressed);
+#else
+	SYS_SetResetCallback(GCResetPressed);
 #endif
 
 	ControllerInit();
@@ -100,6 +104,7 @@ int main(int argc, char **argv)
 	
 #ifdef WII_VERSION	
 	GetWiiRegion();
+#endif
 	
 	if(OffsetH || AspectRatio)
 	{
@@ -109,7 +114,6 @@ int main(int argc, char **argv)
 		}
 		ShowVideoWarning(sd);
 	}
-#endif
 	
 	// load blinking graphics if appropiate
 	if(sd)
@@ -177,10 +181,8 @@ int main(int argc, char **argv)
 		
 		pressed = Controller_ButtonsDown(0);
 
-#ifdef WII_VERSION
 		if(HWButton != -1)
 			EndProgram = 1;
-#endif
 			
 		if ( pressed & PAD_BUTTON_START )
 			DrawMenu = 1;	
@@ -853,6 +855,15 @@ void WiiPowerPressed()
 void WiimotePowerPressed(s32 chan)
 {
 	HWButton = SYS_POWEROFF;
+}
+
+#else
+/**
+ * Callback for the reset button on the GameCube.
+ */
+void GCResetPressed()
+{
+	HWButton = SYS_HOTRESET;
 }
 
 #endif

--- a/240psuite/Wii/240pSuite/source/gba.c
+++ b/240psuite/Wii/240pSuite/source/gba.c
@@ -214,7 +214,7 @@ int gba_displayProgress(ImagePtr title, unsigned int i, unsigned int sendsize) {
 }
 
 u32 checkGBAConnected(unsigned int port) {
-	return(SI_GetType(port) & SI_GBA);
+	return(SI_Probe(port) == SI_GBA);
 }
 
 int detectLink(ImagePtr title, unsigned int port) {
@@ -244,7 +244,7 @@ int detectLink(ImagePtr title, unsigned int port) {
 			return 0;
 	}
 	
-	return(!close && detected && (resval & SI_GBA));
+	return(!close && detected && (SI_DecodeType(resval) == SI_GBA));
 }
 
 int GBASendROM(ImagePtr title, unsigned int port) {

--- a/240psuite/Wii/240pSuite/source/image.c
+++ b/240psuite/Wii/240pSuite/source/image.c
@@ -302,7 +302,6 @@ void IgnoreOffset(ImagePtr image)
 
 ImagePtr LoadImageMemCpy(int Texture, int maptoscreen)
 {		
-	u32 fmt = 0;
 	u16 t_width = 0, t_height = 0;
 	void *texture = NULL;
 	ImagePtr image;
@@ -321,8 +320,8 @@ ImagePtr LoadImageMemCpy(int Texture, int maptoscreen)
 	TPL_GetTextureMEMCopy(&backsTPL, Texture, &image->tex, &texture);
 	
 	//GX_InitTexObjLOD(&image->tex, Options.BilinearFiler, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
-	GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
-	TPL_GetTextureInfo(&backsTPL, Texture, &fmt, &t_width, &t_height);	
+	//GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
+	TPL_GetTextureInfo(&backsTPL, Texture, NULL, &t_width, &t_height);
 
 	image->r = 0xff;
 	image->g = 0xff;
@@ -355,7 +354,6 @@ ImagePtr LoadImageMemCpy(int Texture, int maptoscreen)
 
 ImagePtr LoadImage(int Texture, int maptoscreen)
 {		
-	u32 fmt = 0;
 	u16 t_width = 0, t_height = 0;
 	ImagePtr image;
 	
@@ -373,8 +371,8 @@ ImagePtr LoadImage(int Texture, int maptoscreen)
 	TPL_GetTexture(&backsTPL, Texture, &image->tex);
 	
 	//GX_InitTexObjLOD(&image->tex, Options.BilinearFiler, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
-	GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
-	TPL_GetTextureInfo(&backsTPL, Texture, &fmt, &t_width, &t_height);	
+	//GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
+	TPL_GetTextureInfo(&backsTPL, Texture, NULL, &t_width, &t_height);
 
 	image->r = 0xff;
 	image->g = 0xff;
@@ -427,9 +425,7 @@ ImagePtr CopyFrameBufferToImage()
 			
 	width = rmode->fbWidth;
 	height = rmode->efbHeight;
-	//Darned GX_GetTexBufferSize returns 0! this crashed the suite, no wonder
-	//fbsize = GX_GetTexBufferSize(width, height, GX_TF_RGBA8, GX_TRUE, 0);	
-	fbsize = width * height * 4;  // 32 bits
+	fbsize = GX_GetTexBufferSize(width, height, GX_TF_RGBA8, GX_FALSE, 0);
 	cfb = (u8 *)memalign(32, fbsize);
 	if (!cfb)
 		return NULL;
@@ -462,7 +458,7 @@ ImagePtr CopyFrameBufferToImage()
 	
 	image->cFB = cfb;
 	GX_InitTexObj(&image->tex, image->cFB, width, height, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
-	GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
+	GX_InitTexObjFilterMode(&image->tex, GX_NEAR, GX_NEAR);
 
 	image->r = 0xff;
 	image->g = 0xff;

--- a/240psuite/Wii/240pSuite/source/menu.c
+++ b/240psuite/Wii/240pSuite/source/menu.c
@@ -1177,7 +1177,7 @@ void DrawCredits(ImagePtr Back)
 		y += fh; 
 		y2 = y;
 		DrawStringS(x, y, 0x00, 0xff, 0x00, "SDK:"); y += fh; 
-		DrawStringS(x+5, y, 0xff, 0xff, 0xff, "devkitPPC"); y += fh;
+		DrawStringS(x+5, y, 0xff, 0xff, 0xff, "libogc2/devkitPPC"); y += fh;
 		DrawStringS(x2, y2, 0x00, 0xff, 0x00, "Monoscope Pattern:"); y2 += fh; 
 		DrawStringS(x2+5, y2, 0xff, 0xff, 0xff, "Keith Raney (@khmr33)"); y2 += fh;
 		

--- a/240psuite/Wii/240pSuite/source/myTPL.c
+++ b/240psuite/Wii/240pSuite/source/myTPL.c
@@ -115,8 +115,7 @@ s32 TPL_GetTextureMEMCopy(TPLFile *tdf,s32 id,GXTexObj *texObj, void **texture)
 
 	DCFlushRange(lclhead.data,size);
 	GX_InitTexObj(texObj,lclhead.data,lclhead.width,lclhead.height,lclhead.fmt,lclhead.wraps,lclhead.wrapt,bMipMap);
-	if(bMipMap) GX_InitTexObjLOD(texObj,lclhead.minfilter,lclhead.magfilter,lclhead.minlod,lclhead.maxlod,
-								 lclhead.lodbias,biasclamp,biasclamp,lclhead.edgelod);
+	GX_InitTexObjLOD(texObj,lclhead.minfilter,lclhead.magfilter,lclhead.minlod,lclhead.maxlod,lclhead.lodbias,biasclamp,lclhead.edgelod,GX_ANISO_1);
 
 	*texture = lclhead.data;
 	return 0;

--- a/240psuite/Wii/240pSuite/source/options.c
+++ b/240psuite/Wii/240pSuite/source/options.c
@@ -50,7 +50,7 @@ u8 FSActive = 0;
 
 bool InitSD()
 {
-	if(!__io_wiisd.startup() || !__io_wiisd.isInserted())
+	if(!__io_wiisd.startup(&__io_wiisd) || !__io_wiisd.isInserted(&__io_wiisd))
 		return false;
 
 	return(fatMountSimple("sd", &__io_wiisd));
@@ -59,7 +59,7 @@ bool InitSD()
 void DeInitSD() 
 {
 	fatUnmount("sd:/");
-	__io_wiisd.shutdown();
+	__io_wiisd.shutdown(&__io_wiisd);
 } 
 
 bool InitUSB()
@@ -71,12 +71,12 @@ bool InitUSB()
 
 	while(time(0) - start < 10) // 10 sec
 	{
-		if(__io_usbstorage.startup() && __io_usbstorage.isInserted())
+		if(__io_usbstorage.startup(&__io_usbstorage) && __io_usbstorage.isInserted(&__io_usbstorage))
 				break;
 		usleep(200000); // 1/5 sec
 	}
 	
-	if(!__io_usbstorage.startup() || !__io_usbstorage.isInserted())
+	if(!__io_usbstorage.startup(&__io_usbstorage) || !__io_usbstorage.isInserted(&__io_usbstorage))
 		return false;
 	
 	isMounted = fatMountSimple("usb", &__io_usbstorage);	
@@ -85,7 +85,7 @@ bool InitUSB()
 	{
 		fatUnmount("usb:/");
 		isMounted = fatMountSimple("usb", &__io_usbstorage);	
-		isInserted = __io_usbstorage.isInserted();
+		isInserted = __io_usbstorage.isInserted(&__io_usbstorage);
 		if(isInserted)
 		{
 			int retry = 10;
@@ -107,7 +107,7 @@ bool InitUSB()
 void DeInitUSB()
 {
 	fatUnmount("usb:/");
-	__io_usbstorage.shutdown(); 
+	__io_usbstorage.shutdown(&__io_usbstorage); 
 }
 
 
@@ -176,12 +176,13 @@ void CloseFS()
 #define FS_SDA	3
 #define FS_SDB	4
 #define FS_SD2	5
+#define FS_ODE	6
 
 #include <sdcard/gcsd.h>
 
 bool InitSDA()
 {
-	if(!__io_gcsda.startup() || !__io_gcsda.isInserted())
+	if(!__io_gcsda.startup(&__io_gcsda) || !__io_gcsda.isInserted(&__io_gcsda))
 		return false;
 
 	return(fatMountSimple("sd", &__io_gcsda));
@@ -189,7 +190,7 @@ bool InitSDA()
 
 bool InitSDB()
 {
-	if(!__io_gcsdb.startup() || !__io_gcsdb.isInserted())
+	if(!__io_gcsdb.startup(&__io_gcsdb) || !__io_gcsdb.isInserted(&__io_gcsdb))
 		return false;
 
 	return(fatMountSimple("sd", &__io_gcsdb));
@@ -197,28 +198,42 @@ bool InitSDB()
 
 bool InitSD2()
 {
-	if(!__io_gcsd2.startup() || !__io_gcsd2.isInserted())
+	if(!__io_gcsd2.startup(&__io_gcsd2) || !__io_gcsd2.isInserted(&__io_gcsd2))
 		return false;
 
 	return(fatMountSimple("sd", &__io_gcsd2));
 }
 
+bool InitODE()
+{
+	if(!__io_gcode.startup(&__io_gcode) || !__io_gcode.isInserted(&__io_gcode))
+		return false;
+
+	return(fatMountSimple("sd", &__io_gcode));
+}
+
 void DeInitSDA() 
 {
-	fatUnmount("sd");
-	__io_gcsda.shutdown();
+	fatUnmount("sd:/");
+	__io_gcsda.shutdown(&__io_gcsda);
 }
 
 void DeInitSDB() 
 {
-	fatUnmount("sd");
-	__io_gcsdb.shutdown();
+	fatUnmount("sd:/");
+	__io_gcsdb.shutdown(&__io_gcsdb);
 } 
 
 void DeInitSD2() 
 {
-	fatUnmount("sd");
-	__io_gcsd2.shutdown();
+	fatUnmount("sd:/");
+	__io_gcsd2.shutdown(&__io_gcsd2);
+} 
+
+void DeInitODE() 
+{
+	fatUnmount("sd:/");
+	__io_gcode.shutdown(&__io_gcode);
 } 
 
 u8 InitFS()
@@ -247,6 +262,12 @@ u8 InitFS()
 		fatMounted = 1;
 		path = SD_OPTIONS_PATH;
 		fsType = FS_SD2;
+	}
+	else if(InitODE())
+	{
+		fatMounted = 1;
+		path = SD_OPTIONS_PATH;
+		fsType = FS_ODE;
 	}
 	
 	if (fatMounted)
@@ -281,6 +302,8 @@ void CloseFS()
 			DeInitSDB();
 		if(FSActive == FS_SD2)
 			DeInitSD2();
+		if(FSActive == FS_ODE)
+			DeInitODE();
 		FSActive = 0;
 	}
 }
@@ -651,21 +674,21 @@ u8 LoadOptions()
 			Options.Activate480p = atoi(value);
 	}
 		
-	node = mxmlFindElement(xml, xml, "UseTrapFilter", NULL, NULL, MXML_DESCEND);
-	if (node && mxmlGetType(node) == MXML_ELEMENT)
-	{		
-		const char *value = mxmlGetText(node, NULL);
-		if(value)
-			Options.TrapFilter = atoi(value);
-	}
-	
-#ifdef WII_VERSION	
 	node = mxmlFindElement(xml, xml, "UseDeflickerFilter", NULL, NULL, MXML_DESCEND);
 	if (node && mxmlGetType(node) == MXML_ELEMENT)
 	{		
 		const char *value = mxmlGetText(node, NULL);
 		if(value)
 			Options.FlickerFilter = atoi(value);
+	}
+	
+#ifdef WII_VERSION	
+	node = mxmlFindElement(xml, xml, "UseTrapFilter", NULL, NULL, MXML_DESCEND);
+	if (node && mxmlGetType(node) == MXML_ELEMENT)
+	{		
+		const char *value = mxmlGetText(node, NULL);
+		if(value)
+			Options.TrapFilter = atoi(value);
 	}
 	
 	node = mxmlFindElement(xml, xml, "SFCClassicController", NULL, NULL, MXML_DESCEND);

--- a/240psuite/Wii/240pSuite/source/video.c
+++ b/240psuite/Wii/240pSuite/source/video.c
@@ -163,6 +163,11 @@ void InitVideo()
 	if(CONF_GetVideo() == CONF_VIDEO_PAL ||
 		CONF_GetVideo() == CONF_VIDEO_MPAL)
 		Options.EnablePAL = 1;			
+#else
+	OffsetH = SYS_GetDisplayOffsetH();
+
+	if(SYS_GetVideoMode() == SYS_VIDEO_PAL)
+		Options.EnablePAL = 1;
 #endif
 
 	for(fb = 0; fb < 2; fb++)
@@ -256,6 +261,7 @@ void SetVideoMode(u32 newmode)
 #ifdef WII_VERSION
 	VIDEO_SetTrapFilter(Options.TrapFilter);
 #endif
+	VIDEO_SetAdjustingValues(0, 0);
 	VIDEO_Configure(rmode);			
 	VIDEO_SetNextFramebuffer(frameBuffer[IsPAL][ActiveFB]);
 	VIDEO_Flush();	

--- a/240psuite/Wii/240pSuite/textures/textures.scf
+++ b/240psuite/Wii/240pSuite/textures/textures.scf
@@ -1,78 +1,78 @@
-<filepath="font.png" id="FONTIMG" colfmt=6 />
-<filepath="black.png" id="BLACKIMG" colfmt=6 />
-<filepath="numbers.png" id="NUMBERSIMG" colfmt=6 />
-<filepath="pluge.png" id="PLUGEIMG" colfmt=6 />
-<filepath="grayramp.png" id="GRAYIMG" colfmt=6 />
-<filepath="white.png" id="WHITEIMG" colfmt=6 />
-<filepath="grid.png" id="GRIDIMG" colfmt=6 />
-<filepath="601701cb.png" id="CB601701IMG" colfmt=6 />
-<filepath="color.png" id="COLORIMG" colfmt=6 />
-<filepath="colorhigh.png" id="COLORHIGHIMG" colfmt=6 />
-<filepath="colorlow.png" id="COLORLOWIMG" colfmt=6 />
-<filepath="color_grid.png" id="COLORGRIDIMG" colfmt=6 />
-<filepath="colorbleed.png" id="COLORBLEEDIMG" colfmt=6 />
-<filepath="colorbleedchk.png" id="COLORBLEEDCHKIMG" colfmt=6 />
-<filepath="grid480.png" id="GRID480IMG" colfmt=6 />
-<filepath="100IRE.png" id="IRE100IMG" colfmt=6 />
-<filepath="nish.png" id="NISHIMG" colfmt=6 />
-<filepath="nishgc.png" id="NISHGCIMG" colfmt=6 />
-<filepath="small_grid.png" id="SMALLGRIDIMG" colfmt=6 />
-<filepath="checkpos.png" id="CHECKPOSIMG" colfmt=6 />
-<filepath="checkneg.png" id="CHECKNEGIMG" colfmt=6 />
-<filepath="scanlines.png" id="SCANLINESIMG" colfmt=6 />
-<filepath="kiki.png" id="KIKIBACKIMG" colfmt=6 />
-<filepath="sonicback1.png" id="SONICBACK1IMG" colfmt=6 />
-<filepath="sonicback2.png" id="SONICBACK2IMG" colfmt=6 />
-<filepath="sonicback3.png" id="SONICBACK3IMG" colfmt=6 />
-<filepath="sonicback4.png" id="SONICBACK4IMG" colfmt=6 />
-<filepath="sonicfloor.png" id="SONICFLOORIMG" colfmt=6 />
-<filepath="stripespos.png" id="STRIPESPOSIMG" colfmt=6 />
-<filepath="stripesneg.png" id="STRIPESNEGIMG" colfmt=6 />
-<filepath="diagonal.png" id="DIAGONALIMG" colfmt=6 />
-<filepath="donna.png" id="DONNAIMG" colfmt=6 />
-<filepath="donna-480.png" id="DONNA480IMG" colfmt=6 />
-<filepath="buzzbomber.png" id="BUZZBOMBERIMG" colfmt=6 />
-<filepath="buzzbomberShadow.png" id="BUZZBOMBERSHADOWIMG" colfmt=6 />
-<filepath="shadow.png" id="SHADOWIMG" colfmt=6 />
-<filepath="striped.png" id="STRIPEDIMG" colfmt=6 />
-<filepath="vertstripespos.png" id="VERTSTRIPESPOSIMG" colfmt=6 />
-<filepath="vertstripesneg.png" id="VERTSTRIPESNEGIMG" colfmt=6 />
-<filepath="lag-per.png" id="LAGPERIMG" colfmt=6 />
-<filepath="circle.png" id="CIRCLEIMG" colfmt=6 />
-<filepath="sprite0led.png" id="SPRITE0LEDIMG" colfmt=6 />
-<filepath="sprite1led.png" id="SPRITE1LEDIMG" colfmt=6 />
-<filepath="sprite2led.png" id="SPRITE2LEDIMG" colfmt=6 />
-<filepath="sprite3led.png" id="SPRITE3LEDIMG" colfmt=6 />
-<filepath="sprite4led.png" id="SPRITE4LEDIMG" colfmt=6 />
-<filepath="help.png" id="HELPIMG" colfmt=6 />
-<filepath="SMPTECB75.png" id="SMPTECB75IMG" colfmt=6 />
-<filepath="SMPTECB100.png" id="SMPTECB100IMG" colfmt=6 />
-<filepath="FloatMenu.png" id="FLOATMENUIMG" colfmt=6 />
-<filepath="sharpness.png" id="SHARPNESSIMG" colfmt=6 />
-<filepath="gridPAL.png" id="GRIDPALIMG" colfmt=6 />
-<filepath="gridPAL480.png" id="GRIDPAL480IMG" colfmt=6 />
-<filepath="EBUColorBars75.png" id="EBUCB75IMG" colfmt=6 />
-<filepath="EBUColorBars100.png" id="EBUCB100IMG" colfmt=6 />
-<filepath="plugePAL.png" id="PLUGEPALIMG" colfmt=6 />
-<filepath="PLUGEBorder.png" id="PLUGEBORDERIMG" colfmt=6 />
-<filepath="grid224.png" id="GRID224IMG" colfmt=6 />
-<filepath="phase.png" id="PHASEIMG" colfmt=6 />
-<filepath="longrectangle.png" id="LONGRECTANGLEIMG" colfmt=6 />
-<filepath="Convergence-01-grid.png" id="CONVERGE01" colfmt=6 />
-<filepath="Convergence-02-cross.png" id="CONVERGE02" colfmt=6 />
-<filepath="Convergence-03-dots.png" id="CONVERGE03" colfmt=6 />
-<filepath="Convergence-04-colors.png" id="CONVERGE04" colfmt=6 />
-<filepath="Convergence-05-colorsbl.png" id="CONVERGE05" colfmt=6 />
-<filepath="monoscope.png" id="MONOSCOPEIMG" colfmt=6 />
-<filepath="monoscope_lin.png" id="MONOSCOPELINIMG" colfmt=6 />
-<filepath="monoscopePAL.png" id="MONOSCOPEPALIMG" colfmt=6 />
-<filepath="monoscopePAL_lin.png" id="MONOSCOPEPALLINIMG" colfmt=6 />
-<filepath="monoscope480p.png" id="MONOSCOPE480IMG" colfmt=6 />
-<filepath="monoscope480p_lin.png" id="MONOSCOPE480LINIMG" colfmt=6 />
-<filepath="qr.png" id="QRIMG" colfmt=6 />
-<filepath="gba.png" id="GBAIMG" colfmt=6 />
-<filepath="message.png" id="MSGIMG" colfmt=6 />
-<filepath="back.png" id="BACKIMG" colfmt=6 />
-<filepath="SD_b1.png" id="SD_B1_IMG" colfmt=6 />
-<filepath="SD_b2.png" id="SD_B2_IMG" colfmt=6 />
-<filepath="SD.png" id="SDIMG" colfmt=6 />
+<filepath="font.png" id="FONTIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="black.png" id="BLACKIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="numbers.png" id="NUMBERSIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="pluge.png" id="PLUGEIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="grayramp.png" id="GRAYIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="white.png" id="WHITEIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="grid.png" id="GRIDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="601701cb.png" id="CB601701IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="color.png" id="COLORIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="colorhigh.png" id="COLORHIGHIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="colorlow.png" id="COLORLOWIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="color_grid.png" id="COLORGRIDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="colorbleed.png" id="COLORBLEEDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="colorbleedchk.png" id="COLORBLEEDCHKIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="grid480.png" id="GRID480IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="100IRE.png" id="IRE100IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="nish.png" id="NISHIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="nishgc.png" id="NISHGCIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="small_grid.png" id="SMALLGRIDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="checkpos.png" id="CHECKPOSIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="checkneg.png" id="CHECKNEGIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="scanlines.png" id="SCANLINESIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="kiki.png" id="KIKIBACKIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sonicback1.png" id="SONICBACK1IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sonicback2.png" id="SONICBACK2IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sonicback3.png" id="SONICBACK3IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sonicback4.png" id="SONICBACK4IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sonicfloor.png" id="SONICFLOORIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="stripespos.png" id="STRIPESPOSIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="stripesneg.png" id="STRIPESNEGIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="diagonal.png" id="DIAGONALIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="donna.png" id="DONNAIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="donna-480.png" id="DONNA480IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="buzzbomber.png" id="BUZZBOMBERIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="buzzbomberShadow.png" id="BUZZBOMBERSHADOWIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="shadow.png" id="SHADOWIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="striped.png" id="STRIPEDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="vertstripespos.png" id="VERTSTRIPESPOSIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="vertstripesneg.png" id="VERTSTRIPESNEGIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="lag-per.png" id="LAGPERIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="circle.png" id="CIRCLEIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sprite0led.png" id="SPRITE0LEDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sprite1led.png" id="SPRITE1LEDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sprite2led.png" id="SPRITE2LEDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sprite3led.png" id="SPRITE3LEDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sprite4led.png" id="SPRITE4LEDIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="help.png" id="HELPIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SMPTECB75.png" id="SMPTECB75IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SMPTECB100.png" id="SMPTECB100IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="FloatMenu.png" id="FLOATMENUIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="sharpness.png" id="SHARPNESSIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="gridPAL.png" id="GRIDPALIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="gridPAL480.png" id="GRIDPAL480IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="EBUColorBars75.png" id="EBUCB75IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="EBUColorBars100.png" id="EBUCB100IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="plugePAL.png" id="PLUGEPALIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="PLUGEBorder.png" id="PLUGEBORDERIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="grid224.png" id="GRID224IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="phase.png" id="PHASEIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="longrectangle.png" id="LONGRECTANGLEIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="Convergence-01-grid.png" id="CONVERGE01" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="Convergence-02-cross.png" id="CONVERGE02" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="Convergence-03-dots.png" id="CONVERGE03" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="Convergence-04-colors.png" id="CONVERGE04" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="Convergence-05-colorsbl.png" id="CONVERGE05" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="monoscope.png" id="MONOSCOPEIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="monoscope_lin.png" id="MONOSCOPELINIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="monoscopePAL.png" id="MONOSCOPEPALIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="monoscopePAL_lin.png" id="MONOSCOPEPALLINIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="monoscope480p.png" id="MONOSCOPE480IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="monoscope480p_lin.png" id="MONOSCOPE480LINIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="qr.png" id="QRIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="gba.png" id="GBAIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="message.png" id="MSGIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="back.png" id="BACKIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SD_b1.png" id="SD_B1_IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SD_b2.png" id="SD_B2_IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SD.png" id="SDIMG" colfmt=6 minfilt=0 magfilt=0 />

--- a/240psuite/Wii/AudioPlayer/Makefile
+++ b/240psuite/Wii/AudioPlayer/Makefile
@@ -12,12 +12,12 @@ PLATFORM ?= wii
 TARGET		:=	$(notdir $(CURDIR))
 
 ifeq ($(PLATFORM),wii)
-include $(DEVKITPPC)/wii_rules
+include $(DEVKITPRO)/libogc2/wii_rules
 TARGET:="$(TARGET)_wii"
 EXTRA_LIBS=-lwiiuse -lbte
 EXTRA_FLAGS=-DWII_VERSION
 else
-include $(DEVKITPPC)/gamecube_rules
+include $(DEVKITPRO)/libogc2/gamecube_rules
 TARGET:="$(TARGET)_cube"
 EXTRA_FLAGS=-DGC_VERSION
 endif

--- a/240psuite/Wii/AudioPlayer/source/240psuite.c
+++ b/240psuite/Wii/AudioPlayer/source/240psuite.c
@@ -38,11 +38,13 @@ int EndProgram = 0;
 ImagePtr 	sd_b1 = NULL, sd_b2 = NULL;
 void SD_blink_cycle();
 
+s8 HWButton = -1;
 #ifdef WII_VERSION
-s8 HWButton = -1; 
 void WiiResetPressed();
 void WiiPowerPressed();
 void WiimotePowerPressed(s32 chan);
+#else
+void GCResetPressed();
 #endif
 
 #include "dirent.h"
@@ -105,6 +107,8 @@ int main(int argc, char **argv)
 	SYS_SetResetCallback(WiiResetPressed);
 	SYS_SetPowerCallback(WiiPowerPressed);
 	WPAD_SetPowerButtonCallback(WiimotePowerPressed);
+#else
+	SYS_SetResetCallback(GCResetPressed);
 #endif
 
 	ControllerInit();
@@ -195,10 +199,8 @@ int main(int argc, char **argv)
 		
 		pressed = Controller_ButtonsDown(0);
 
-#ifdef WII_VERSION
 		if(HWButton != -1)
 			EndProgram = 1;
-#endif
 			
 		if ( pressed & PAD_BUTTON_UP )
 		{
@@ -303,6 +305,15 @@ void WiiPowerPressed()
 void WiimotePowerPressed(s32 chan)
 {
 	HWButton = SYS_POWEROFF;
+}
+
+#else
+/**
+ * Callback for the reset button on the GameCube.
+ */
+void GCResetPressed()
+{
+	HWButton = SYS_HOTRESET;
 }
 
 #endif

--- a/240psuite/Wii/AudioPlayer/source/image.c
+++ b/240psuite/Wii/AudioPlayer/source/image.c
@@ -289,7 +289,6 @@ void IgnoreOffset(ImagePtr image)
 
 ImagePtr LoadImageMemCpy(int Texture, int maptoscreen)
 {		
-	u32 fmt = 0;
 	u16 t_width = 0, t_height = 0;
 	void *texture = NULL;
 	ImagePtr image;
@@ -308,8 +307,8 @@ ImagePtr LoadImageMemCpy(int Texture, int maptoscreen)
 	TPL_GetTextureMEMCopy(&backsTPL, Texture, &image->tex, &texture);	
 	
 	//GX_InitTexObjLOD(&image->tex, Options.BilinearFiler, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
-	GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);	
-	TPL_GetTextureInfo(&backsTPL, Texture, &fmt, &t_width, &t_height);	
+	//GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
+	TPL_GetTextureInfo(&backsTPL, Texture, NULL, &t_width, &t_height);
 
 	image->r = 0xff;
 	image->g = 0xff;
@@ -342,7 +341,6 @@ ImagePtr LoadImageMemCpy(int Texture, int maptoscreen)
 
 ImagePtr LoadImage(int Texture, int maptoscreen)
 {		
-	u32 fmt = 0;
 	u16 t_width = 0, t_height = 0;
 	ImagePtr image;
 	
@@ -360,8 +358,8 @@ ImagePtr LoadImage(int Texture, int maptoscreen)
 	TPL_GetTexture(&backsTPL, Texture, &image->tex);	
 	
 	//GX_InitTexObjLOD(&image->tex, Options.BilinearFiler, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
-	GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);	
-	TPL_GetTextureInfo(&backsTPL, Texture, &fmt, &t_width, &t_height);	
+	//GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);
+	TPL_GetTextureInfo(&backsTPL, Texture, NULL, &t_width, &t_height);
 
 	image->r = 0xff;
 	image->g = 0xff;
@@ -414,9 +412,7 @@ ImagePtr CopyFrameBufferToImage()
 			
 	width = rmode->fbWidth;
 	height = rmode->efbHeight;
-	//Darned GX_GetTexBufferSize returns 0! this crashed the suite, no wonder
-	//fbsize = GX_GetTexBufferSize(width, height, GX_TF_RGBA8, GX_TRUE, 0);	
-	fbsize = width * height * 4;  // 32 bits	
+	fbsize = GX_GetTexBufferSize(width, height, GX_TF_RGBA8, GX_FALSE, 0);
 	cfb = (u8 *)memalign(32, fbsize);
 	if (!cfb)
 		return NULL;
@@ -449,7 +445,7 @@ ImagePtr CopyFrameBufferToImage()
 	
 	image->cFB = cfb;
 	GX_InitTexObj(&image->tex, image->cFB, width, height, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
-	GX_InitTexObjLOD(&image->tex, GX_NEAR, GX_NEAR, 0.0, 10.0, 0.0, GX_FALSE, GX_FALSE, GX_ANISO_1);				
+	GX_InitTexObjFilterMode(&image->tex, GX_NEAR, GX_NEAR);
 
 	image->r = 0xff;
 	image->g = 0xff;

--- a/240psuite/Wii/AudioPlayer/source/myTPL.c
+++ b/240psuite/Wii/AudioPlayer/source/myTPL.c
@@ -115,8 +115,7 @@ s32 TPL_GetTextureMEMCopy(TPLFile *tdf,s32 id,GXTexObj *texObj, void **texture)
 
 	DCFlushRange(lclhead.data,size);
 	GX_InitTexObj(texObj,lclhead.data,lclhead.width,lclhead.height,lclhead.fmt,lclhead.wraps,lclhead.wrapt,bMipMap);
-	if(bMipMap) GX_InitTexObjLOD(texObj,lclhead.minfilter,lclhead.magfilter,lclhead.minlod,lclhead.maxlod,
-								 lclhead.lodbias,biasclamp,biasclamp,lclhead.edgelod);
+	GX_InitTexObjLOD(texObj,lclhead.minfilter,lclhead.magfilter,lclhead.minlod,lclhead.maxlod,lclhead.lodbias,biasclamp,lclhead.edgelod,GX_ANISO_1);
 
 	*texture = lclhead.data;
 	return 0;

--- a/240psuite/Wii/AudioPlayer/source/options.c
+++ b/240psuite/Wii/AudioPlayer/source/options.c
@@ -49,7 +49,7 @@ u8 FSActive = 0;
 
 bool InitSD()
 {
-	if(!__io_wiisd.startup() || !__io_wiisd.isInserted())
+	if(!__io_wiisd.startup(&__io_wiisd) || !__io_wiisd.isInserted(&__io_wiisd))
 		return false;
 
 	return(fatMountSimple("sd", &__io_wiisd));
@@ -58,7 +58,7 @@ bool InitSD()
 void DeInitSD() 
 {
 	fatUnmount("sd:/");
-	__io_wiisd.shutdown();
+	__io_wiisd.shutdown(&__io_wiisd);
 } 
 
 bool InitUSB()
@@ -70,12 +70,12 @@ bool InitUSB()
 
 	while(time(0) - start < 10) // 10 sec
 	{
-		if(__io_usbstorage.startup() && __io_usbstorage.isInserted())
+		if(__io_usbstorage.startup(&__io_usbstorage) && __io_usbstorage.isInserted(&__io_usbstorage))
 				break;
 		usleep(200000); // 1/5 sec
 	}
 	
-	if(!__io_usbstorage.startup() || !__io_usbstorage.isInserted())
+	if(!__io_usbstorage.startup(&__io_usbstorage) || !__io_usbstorage.isInserted(&__io_usbstorage))
 		return false;
 	
 	isMounted = fatMountSimple("usb", &__io_usbstorage);	
@@ -84,7 +84,7 @@ bool InitUSB()
 	{
 		fatUnmount("usb:/");
 		isMounted = fatMountSimple("usb", &__io_usbstorage);	
-		isInserted = __io_usbstorage.isInserted();
+		isInserted = __io_usbstorage.isInserted(&__io_usbstorage);
 		if(isInserted)
 		{
 			int retry = 10;
@@ -106,7 +106,7 @@ bool InitUSB()
 void DeInitUSB()
 {
 	fatUnmount("usb:/");
-	__io_usbstorage.shutdown(); 
+	__io_usbstorage.shutdown(&__io_usbstorage); 
 }
 
 
@@ -175,12 +175,13 @@ void CloseFS()
 #define FS_SDA	3
 #define FS_SDB	4
 #define FS_SD2	5
+#define FS_ODE	6
 
 #include <sdcard/gcsd.h>
 
 bool InitSDA()
 {
-	if(!__io_gcsda.startup() || !__io_gcsda.isInserted())
+	if(!__io_gcsda.startup(&__io_gcsda) || !__io_gcsda.isInserted(&__io_gcsda))
 		return false;
 
 	return(fatMountSimple("sd", &__io_gcsda));
@@ -188,7 +189,7 @@ bool InitSDA()
 
 bool InitSDB()
 {
-	if(!__io_gcsdb.startup() || !__io_gcsdb.isInserted())
+	if(!__io_gcsdb.startup(&__io_gcsdb) || !__io_gcsdb.isInserted(&__io_gcsdb))
 		return false;
 
 	return(fatMountSimple("sd", &__io_gcsdb));
@@ -196,28 +197,42 @@ bool InitSDB()
 
 bool InitSD2()
 {
-	if(!__io_gcsd2.startup() || !__io_gcsd2.isInserted())
+	if(!__io_gcsd2.startup(&__io_gcsd2) || !__io_gcsd2.isInserted(&__io_gcsd2))
 		return false;
 
 	return(fatMountSimple("sd", &__io_gcsd2));
 }
 
+bool InitODE()
+{
+	if(!__io_gcode.startup(&__io_gcode) || !__io_gcode.isInserted(&__io_gcode))
+		return false;
+
+	return(fatMountSimple("sd", &__io_gcode));
+}
+
 void DeInitSDA() 
 {
-	fatUnmount("sd");
-	__io_gcsda.shutdown();
+	fatUnmount("sd:/");
+	__io_gcsda.shutdown(&__io_gcsda);
 }
 
 void DeInitSDB() 
 {
-	fatUnmount("sd");
-	__io_gcsdb.shutdown();
+	fatUnmount("sd:/");
+	__io_gcsdb.shutdown(&__io_gcsdb);
 } 
 
 void DeInitSD2() 
 {
-	fatUnmount("sd");
-	__io_gcsd2.shutdown();
+	fatUnmount("sd:/");
+	__io_gcsd2.shutdown(&__io_gcsd2);
+} 
+
+void DeInitODE() 
+{
+	fatUnmount("sd:/");
+	__io_gcode.shutdown(&__io_gcode);
 } 
 
 u8 InitFS()
@@ -246,6 +261,12 @@ u8 InitFS()
 		fatMounted = 1;
 		path = SD_OPTIONS_PATH;
 		fsType = FS_SD2;
+	}
+	else if(InitODE())
+	{
+		fatMounted = 1;
+		path = SD_OPTIONS_PATH;
+		fsType = FS_ODE;
 	}
 	
 	if (fatMounted)
@@ -280,6 +301,8 @@ void CloseFS()
 			DeInitSDB();
 		if(FSActive == FS_SD2)
 			DeInitSD2();
+		if(FSActive == FS_ODE)
+			DeInitODE();
 		FSActive = 0;
 	}
 }

--- a/240psuite/Wii/AudioPlayer/source/tests.c
+++ b/240psuite/Wii/AudioPlayer/source/tests.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "tests.h"
@@ -43,9 +44,9 @@ void DrawMessage(ImagePtr back, char *title, char *msg)
 
 extern int EndProgram;
 
-void aesnd_callback(AESNDPB *pb, unsigned int state, void *cb_arg)
+void aesnd_callback(AESNDPB *pb, unsigned int state)
 {
-	unsigned int *playback = (unsigned int *)cb_arg;
+	unsigned int *playback = AESND_GetVoiceUserData(pb);
 	
 	if (state == VOICE_STATE_RUNNING) 
 		*playback = 1;
@@ -66,10 +67,10 @@ void PlayAudioFile(ImagePtr back, char *filename)
 
 	AESND_Init();
 	
-	voice = AESND_AllocateVoiceWithArg(aesnd_callback, &playback);
+	voice = AESND_AllocateVoice(aesnd_callback);
 	if(!voice)
 		return;
-	AESND_SetVoiceVolume(voice, 0xff, 0xff);
+	AESND_SetVoiceUserData(voice, &playback);
 
 	while(counter --)
 		DrawMessage(back, title, msg);
@@ -121,7 +122,7 @@ void PlayAudioFile(ImagePtr back, char *filename)
 				
 				msg = "Playing Audio File";
 
-				AESND_PlayVoice(voice, VOICE_STEREO16, aet_samples, aet_size, DSP_DEFAULT_FREQ, 0, 0);
+				AESND_PlayVoice(voice, VOICE_STEREO16, aet_samples, aet_size, lrintf(DSP_DEFAULT_FREQ), 0, false);
 				
 				while(playback != 1)
 					DrawMessage(back, title, msg);

--- a/240psuite/Wii/AudioPlayer/source/video.c
+++ b/240psuite/Wii/AudioPlayer/source/video.c
@@ -163,6 +163,11 @@ void InitVideo()
 	if(CONF_GetVideo() == CONF_VIDEO_PAL ||
 		CONF_GetVideo() == CONF_VIDEO_MPAL)
 		Options.EnablePAL = 1;			
+#else
+	OffsetH = SYS_GetDisplayOffsetH();
+
+	if(SYS_GetVideoMode() == SYS_VIDEO_PAL)
+		Options.EnablePAL = 1;
 #endif
 
 	for(fb = 0; fb < 2; fb++)
@@ -256,6 +261,7 @@ void SetVideoMode(u32 newmode)
 #ifdef WII_VERSION
 	VIDEO_SetTrapFilter(Options.TrapFilter);
 #endif
+	VIDEO_SetAdjustingValues(0, 0);
 	VIDEO_Configure(rmode);			
 	VIDEO_SetNextFramebuffer(frameBuffer[IsPAL][ActiveFB]);			
 	VIDEO_Flush();	

--- a/240psuite/Wii/AudioPlayer/textures/textures.scf
+++ b/240psuite/Wii/AudioPlayer/textures/textures.scf
@@ -1,7 +1,7 @@
-<filepath="font.png" id="FONTIMG" colfmt=6 />
-<filepath="black.png" id="BLACKIMG" colfmt=6 />
-<filepath="white.png" id="WHITEIMG" colfmt=6 />
-<filepath="back.png" id="BACKIMG" colfmt=6 />
-<filepath="SD_b1.png" id="SD_B1_IMG" colfmt=6 />
-<filepath="SD_b2.png" id="SD_B2_IMG" colfmt=6 />
-<filepath="SD.png" id="SDIMG" colfmt=6 />
+<filepath="font.png" id="FONTIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="black.png" id="BLACKIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="white.png" id="WHITEIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="back.png" id="BACKIMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SD_b1.png" id="SD_B1_IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SD_b2.png" id="SD_B2_IMG" colfmt=6 minfilt=0 magfilt=0 />
+<filepath="SD.png" id="SDIMG" colfmt=6 minfilt=0 magfilt=0 />


### PR DESCRIPTION
This is a proposal to migrate the 240p Test Suite to [libogc2](https://github.com/extremscorner/libogc2).

Advantages:
- Return to loader (Swiss) support on GameCube
- Improved support for GameCube SD card adapters, including the ETH2GC Sidecar+
- GC Loader read/write support
- exFAT and large disk support (via `libogc2-libdvm-git` package)
- Possibly more, I forget

Disadvantages:
- A certain group who prefer not to be named may be unhappy

These relevant [pacman packages](https://github.com/extremscorner/pacman-packages) are applicable:
- `gamecube-tools-git` (for improved `gxtexconv`)
- `libogc2-git`
- `libogc2-libdvm-git` (or `libogc2-libfat-git` if there are patent concerns)
- `ppc-zlib-ng-compat` (optional, for faster decompression)

If you need help setting this up, I'm always available on Discord.